### PR TITLE
Add HMM-functional-annotator as a submodule under projects

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "projects/HMM-functional-annotator"]
+	path = projects/HMM-functional-annotator
+	url = git@github.com:jjjoy-x/HMM-functional-annotator.git


### PR DESCRIPTION
This PR adds the `HMM-functional-annotator` repository as a submodule under "plaszyme".

### Usage
After merging this PR, run the following commands to initialize and update the submodule:

```bash
git submodule update --init --recursive
git lfs install
git lfs fetch --all
git lfs checkout
